### PR TITLE
Making sure a default value for a property or parameter can contain a non empty array.

### DIFF
--- a/src/visitor/DefaultVisitor.php
+++ b/src/visitor/DefaultVisitor.php
@@ -224,16 +224,9 @@ class DefaultVisitor implements GeneratorVisitorInterface {
 	}
 
 	protected function getPhpExport($value) {
-		if (is_bool($value)) {
-			return $value ? 'true' : 'false';
-		}
-
+		// Simply to be sure a null value is displayed in lowercase.
 		if (null === $value) {
 			return 'null';
-		}
-
-		if (is_array($value)) {
-			return 'array()';
 		}
 
 		return var_export($value, true);

--- a/tests/Visitor/DefaultVisitorTest.php
+++ b/tests/Visitor/DefaultVisitorTest.php
@@ -3,6 +3,7 @@ namespace gossi\codegen\tests\visitor;
 
 use gossi\codegen\model\PhpFunction;
 use gossi\codegen\model\PhpParameter;
+use gossi\codegen\model\PhpProperty;
 use gossi\codegen\visitor\DefaultVisitor;
 use gossi\codegen\model\PhpMethod;
 use gossi\codegen\utils\Writer;
@@ -51,6 +52,17 @@ class DefaultVisitorTest extends \PHPUnit_Framework_TestCase {
 		
 		$this->assertEquals($this->getContent('callable_parameter.php'), $visitor->getContent());
 	}
+
+	public function testDefaultNotEmptyArray() {
+		$property = new PhpProperty('fooArray');
+		$visitor = new DefaultVisitor();
+
+		$property->setDefaultValue(array("some value"));
+		$visitor->visitProperty($property);
+
+		$this->assertContains("some value", $visitor->getContent());
+	}
+
 
 	/**
 	 *


### PR DESCRIPTION
Hi Thomas!

I've been facing a problem using the `setDefaultValue()` method with non empty arrays.

So far, the code

```php
$property = new PhpProperty('fooArray');
$property->setDefaultValue(array("some value"));
```

would fail to generate

```php
public $fooArray = array('some value');
```

Instead, it would generate:

```php
public $fooArray = array();
```

This pull-request contains a fix (and a new unit-test case).

Thanks for your work man!