### PR TITLE
Bump allowable maximum versions for sami & php-parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,11 +27,11 @@
 		"symfony/options-resolver" : "~2|~3",
 		"phootwork/file" : "~0",
 		"phootwork/tokenizer" : "~0",
-		"nikic/php-parser" : "~1|~2"
+		"nikic/php-parser" : "~1|~2|~3"
 	},
 	"require-dev" : {
 		"phpunit/phpunit" : "~4",
-		"sami/sami" : "~3"
+		"sami/sami" : "~3|~4"
 	},
 	"suggest" : {
 		"gossi/php-code-formatter" : "Formatting your generated code"


### PR DESCRIPTION
## What
 * Add `~3` to the allowed versions for `nikic/php-parser` (necessary)
 * Add `~4` to the allowed versions list for `sami/sami` (nice-to-have)

## Why
Because using this library in a project that also requires sami ~4 is currently impossible, as sami ~4 requires php-parser ~3.